### PR TITLE
Tweak plugin

### DIFF
--- a/fluent-plugin-teams.gemspec
+++ b/fluent-plugin-teams.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'fluentd', ['>= 0.12', '< 2']
+  spec.add_dependency 'fluentd', ['>= 0.14.15', '< 2']
   spec.add_dependency 'rest-client'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/lib/fluent/plugin/out_teams.rb
+++ b/lib/fluent/plugin/out_teams.rb
@@ -6,11 +6,21 @@ module Fluent
     class TeamsOutput < Output
       Fluent::Plugin.register_output('teams', self)
 
+      DEFAULT_BUFFER_TYPE = 'memory'.freeze
+
       desc 'Webhook URL'
       config_param :webhook_url, :string
 
       desc 'Message content. Supported erb format and newline character.'
       config_param :text, :string
+
+      desc 'Use buffered processing'
+      config_param :buffered, :bool, :default => false
+
+      config_section :buffer do
+        config_set_default :@type, DEFAULT_BUFFER_TYPE
+        config_set_default :chunk_keys, ['tag']
+      end
 
       def initialize
         super
@@ -37,7 +47,7 @@ module Fluent
       end
 
       def prefer_buffered_processing
-        false
+        @buffered
       end
 
       def process(tag, es)

--- a/spec/fluent/plugin/teams_spec.rb
+++ b/spec/fluent/plugin/teams_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe Fluent::Plugin::TeamsOutput do
     it 'should get text' do
       expect(instance.text).to eq 'hoge fuga'
     end
+
+    it 'should get false' do
+      expect(instance.buffered).to be_falsy
+    end
+
+    it 'should set as memory buffer type' do
+      expect(instance.buffer_config[:@type]).to include 'memory'
+    end
+
+    it 'should contain tag in chunk_keys' do
+      expect(instance.buffer_config.chunk_keys).to include 'tag'
+    end
   end
 
   describe '#build_payload' do


### PR DESCRIPTION
Hi, @nyamairi.
Could you kindly take a look?

---

* Depends on v0.14.15 or later because `#formatted_to_msgpack_binary?` is provided since Fluentd v0.14.15 or later
* Support buffered processing operation 
  - When secifying `buffered` as true, #write method will be called instead of #process.
* Specify `tag` chunk key by default on buffered mode